### PR TITLE
fixing bug where a missing file causes an error upon calling getConfig()

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var Crampon = module.exports = function(hierarchy) {
 			if(!suppressErrors) throw e;
 		}
 
-		return config;
+		return config||{};
 	}
 
 	function appendHierarchical(conf) {

--- a/test/crampon.test.js
+++ b/test/crampon.test.js
@@ -148,6 +148,16 @@ describe('crampon', function() {
 			});
 		});
 
+		it('should not error out when adding a non-existant file and calling getConfig()', function() {
+				var crampon = new Crampon();
+
+				assert.doesNotThrow(function() {
+					crampon
+						.addFile('badfile', true)
+						.getConfig();
+				});
+		});
+
 	});
 
 	describe('with hierarchy', function() {
@@ -349,6 +359,16 @@ describe('crampon', function() {
 			assert.doesNotThrow(function() {
 				crampon.addOverrideFile('badfile', true);
 			});
+		});
+
+		it('should not error out when adding a non-existant file and calling getConfig()', function() {
+				var crampon = new Crampon(hierarchy);
+
+				assert.doesNotThrow(function() {
+					crampon
+						.addOverrideFile('badfile', true)
+						.getConfig('dev');
+				});
 		});
 
 	});


### PR DESCRIPTION
Defaulted config to an empty object in `getFile()` - otherwise it uses a `null` value for that entry in the config objects, and when trying to merge them together, deap throws an error.  I chose to default it in `getFile()` as it is the earliest place to catch the problem, and doesn't introduce unexpected defaulting in other scenarios.
