### PR TITLE
bumping deap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "./node_modules/.bin/mocha test/*.test.js"
   },
   "dependencies": {
-    "deap": "^0.2.2"
+    "deap": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "~1.9.0",


### PR DESCRIPTION
bumping `deap` to `1.0.0`

No api changes between `0.2.2` and `1.0.0`, this is merely just to update to latest major version.
